### PR TITLE
Add new mode

### DIFF
--- a/readme.rst
+++ b/readme.rst
@@ -23,6 +23,9 @@ mode
    "fillmargins"
       Fills the borders exactly like the Avisynth filter `FillMargins <http://forum.doom9.org/showthread.php?t=50132>`_, version 1.0.2.0. This mode is similar to "repeat", except that each pixel at the top and bottom borders is filled with a weighted average of its three neighbours from the previous line.
 
+   "fixborders"
+      A direction "aware" modification of FillMargins. It also works on all four sides.
+
    "interlaced"
       Fills the top and bottom borders only with pixels taken from the same field. Possible values are 1 (always on), 0 (always off), and -1 (uses the _FieldBased frame property to decide if interlaced processing should be used or not).
 


### PR DESCRIPTION
I modified the fillmargins mode a bit to make a new mode that  works on all four sides and tries to figure out a direction for the fill to assume. If it determines something is going left or right, it uses weights [5, 3, 1]. Otherwise, it uses weights [1, 3, 1].

Determining the direction is just a basic diff between fill and a reference pixel, then comparing that to the diff between the reference pixel and a blur of the reference pixel and its two surrounding pixels.

Here's a quick comparison:  https://slow.pics/c/49hYNpKc